### PR TITLE
redundant 'the' removed.

### DIFF
--- a/switch.rst
+++ b/switch.rst
@@ -668,7 +668,7 @@ placing them in the larger ecosystem. Keeping in mind that
 fixed-function switching chips still dominate the market, we do not
 mean to understate their value or the role they will undoubtedly
 continue to play.\ [#]_ But they do remove one degree-of-freedom—the
-ability to reprogram the data plane—which helps to highlight the the
+ability to reprogram the data plane—which helps to highlight the
 relationship between all the moving parts introduced in this chapter.
 
 .. [#] The distinction between fixed-function and programmable


### PR DESCRIPTION
This must be a typo.