### PR TITLE
Fixed some typos and grammatical mistakes until chapter 4

### DIFF
--- a/code/ingress.p4
+++ b/code/ingress.p4
@@ -14,7 +14,7 @@ control MyIngress(
     action ipv4_forward(macAddr_t dstAddr,
 			egressSpec_t port) {
 	standard_metadata.egress_spec = port;
-        hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
+        hdr.ethernet.srcAddr = hdr.ethernet.srcAddr;
         hdr.ethernet.dstAddr = dstAddr;
         hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
     }

--- a/code/ingress.p4
+++ b/code/ingress.p4
@@ -14,7 +14,7 @@ control MyIngress(
     action ipv4_forward(macAddr_t dstAddr,
 			egressSpec_t port) {
 	standard_metadata.egress_spec = port;
-        hdr.ethernet.srcAddr = hdr.ethernet.srcAddr;
+        hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
         hdr.ethernet.dstAddr = dstAddr;
         hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
     }

--- a/code/v1model.p4
+++ b/code/v1model.p4
@@ -24,7 +24,7 @@ control MyVerifyChecksum(
     ...
 }
 
-/* Ingress Proceessing */
+/* Ingress Processing */
 control MyIngress(
 	inout headers hdr,
 	inout metadata meta,
@@ -32,7 +32,7 @@ control MyIngress(
     ...
 }
 
-/* Egress Proceessing */
+/* Egress Processing */
 control MyEgress(
 	inout headers hdr,
 	inout metadata meta,

--- a/intro.rst
+++ b/intro.rst
@@ -527,7 +527,7 @@ cluster of servers mitigates both these concerns, as techniques developed in
 the distributed systems world can ensure both high availability and
 scalability of such clusters.
 
-A secondary concern raised about control plan centralization is  
+A secondary concern raised about control plane centralization is  
 that, since the control plane is remote (i.e., off-switch), the link 
 between the two planes adds a vulnerable attack surface. The 
 counter-argument is that non-SDN networks already have (and depend on) 

--- a/switch.rst
+++ b/switch.rst
@@ -816,7 +816,7 @@ The two leftmost examples exist today, and represent the canonical
 layers for programmable and fixed-function ASICs, respectively. The
 middle example is purely hypothetical, but it illustrates that it is
 possible to define a P4-based stack even for a fixed-function pipeline
-(and by implication, control it using P4Runtime). The fourth example
+(and, by implication, control it using P4Runtime). The fourth example
 also exists today, and is how Broadcom ASICs conform to the
 SAI-defined logical pipeline. Finally, the rightmost example projects
 into the future, when SAI is extended to support P4 programmability

--- a/switch.rst
+++ b/switch.rst
@@ -256,7 +256,7 @@ an abstract target machine, analogous to a Java Virtual Machine. The
 goal is the same as for Java: to support a *write-once-run-anywhere*
 programming paradigm. (Note that :numref:`Figure %s <fig-psa>`
 includes the generic ``arch.p4`` as the architecture model spec,
-but in practice the architecture model would PSA specific, such as
+but in practice the architecture model would be PSA specific, such as
 ``psa.p4``.)
 
 .. _fig-psa:

--- a/switch.rst
+++ b/switch.rst
@@ -431,7 +431,7 @@ discover we need a new feature.
 	the control plane yet! What we've covered so far is complex
 	with or without SDN. That's because we're working at the SW/HW
 	boundary, and the hardware is designed to forward packets at
-	rates measured in Terabits-per-second. This complexity use to
+	rates measured in Terabits-per-second. This complexity used to
 	be hidden inside proprietary devices. One thing SDN has done
 	is put pressure on the marketplace to open up that space so
 	others can innovate.*

--- a/switch.rst
+++ b/switch.rst
@@ -716,8 +716,8 @@ but the reader will recognize tables for several well-known protocols.
 For our purposes, what is instructive is to see how OF-DPA maps onto
 its programmable pipeline counterparts. In the programmable case, it’s
 not until you add a program like ``switch.p4`` that you get something
-roughly equivalent OF-DPA. That is, ``v1model.p4`` defines the available
-stages (control blocks). bit it's not until you add ``switch.p4`` that you
+roughly equivalent to OF-DPA. That is, ``v1model.p4`` defines the available
+stages (control blocks). But it's not until you add ``switch.p4`` that you
 have the functionality that runs in those stages.
 
 With this relationship in mind, we might want to incorporate both
@@ -742,9 +742,9 @@ forwarding pipelines—it necessarily focuses on the subset of
 functionality all vendors can agree on, the least common denominator,
 so to speak.
 
-SAI includes both a configuration interface and a control interface,
-where its the control interface that’s most relevant to this section
-because it abstracts the forwarding pipeline. On the other hand, there
+SAI includes both a configuration interface and a control interface, 
+where it's the latter that is most relevant to this section because 
+it abstracts the forwarding pipeline. On the other hand, there
 is little value in looking at yet another forwarding pipeline, so we
 refer the interested reader to the SAI specification for more details.
 

--- a/switch.rst
+++ b/switch.rst
@@ -431,7 +431,7 @@ discover we need a new feature.
 	the control plane yet! What we've covered so far is complex
 	with or without SDN. That's because we're working at the SW/HW
 	boundary, and the hardware is designed to forward packets at
-	rates measured in Terabits-per-second. This complexity used to
+	rates measured in Terabits-per-second. This complexity use to
 	be hidden inside proprietary devices. One thing SDN has done
 	is put pressure on the marketplace to open up that space so
 	others can innovate.*

--- a/switch.rst
+++ b/switch.rst
@@ -797,8 +797,8 @@ layers: a switching chip ASIC, a vendor-specific SDK for programming
 the ASIC, and a definition of the forwarding pipeline. By providing a
 programmatic interface, the SDKs in the middle layer effectively
 abstract the underlying hardware. They are either conventional (e.g.,
-the Broadcom SDK shown in the second and fourth examples) or as just
-pointed out, logically corresponds to a P4 architecture model paired
+the Broadcom SDK shown in the second and fourth examples) or, as just
+pointed out, logically correspond to a P4 architecture model paired
 with an ASIC-specific P4 compiler.  The topmost layer in all five
 examples defines a logical pipeline that can subsequently be
 controlled using a control interface like OpenFlow or P4Runtime (not

--- a/uses.rst
+++ b/uses.rst
@@ -592,7 +592,7 @@ used, for example, to detect *microbursts*—queuing delays measured
 over millisecond or even sub-millisecond time scales—as reported by
 Xiaoqi Chen and colleagues.  It is even possible to correlate this
 information across packet flows that followed different routes, so as
-to to determine which flows shared buffer capacity at each switch.
+to determine which flows shared buffer capacity at each switch.
 
 .. _reading_int:
 .. admonition:: Further Reading


### PR DESCRIPTION
I have read the excellent book with scrutiny, and I thought I could make it better by correcting some typos. 

I have some doubts about my understanding of P4 (Section 4.4.3). In commit c84e29abc159d1d5056ead1e4801474c4cdf7bf1 (line 17 correct me if I'm wrong or misunderstood!), I changed "hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;" since I guessed it was a typo. 

I am genuinely grateful to Larry Paterson and the team for sharing this superior SDN knowledge in a relatively easy chronological order.


Best regards, 
Sina