### PR TITLE
Fixed some typos and grammatical mistakes in Chapters 7,8, and 9

### DIFF
--- a/access.rst
+++ b/access.rst
@@ -274,7 +274,7 @@ example, when an ONU comes online (corresponding to a port on the
 logical switch becoming active), an 802.1X authorization sequence is
 initiated, verifying that the ONU is registered to a known customer.
 One outcome of a successful authorization is that the SD-PON
-application instructs ONOS to set up a path though the fabric (with
+application instructs ONOS to set up a path through the fabric (with
 the prescribed QoS profile) connecting that subscriber to the L2
 network. Next, a home router connected to the ONU will then send a
 DHCP request, both triggering an IP address assignment and causing
@@ -309,7 +309,7 @@ stations in a given geographic area coordinate with each other to
 allocate the shared—and scarce—radio spectrum. They make
 hand-off decisions, decide to jointly serve a given user (think of
 this as a RAN variant of link aggregation), and make packet scheduling
-decisions based on continual measurements of the signal quality. Today
+decisions based on continual measurements of the signal quality. Today,
 these are purely local decisions, but transforming it into a global
 optimization problem is in SDN’s wheelhouse.
 
@@ -498,8 +498,8 @@ for all the base stations and user devices, including which base
 station is serving each user device, as well as the set of “potential
 links” that could connect the device.  The Telemetry Service, which
 builds on a *Time Series Database (TSDB)*, tracks all the link quality
-information being reported back by the RAN elements. Various of the
-control applications then analyze this data to make informed decisions
+information being reported back by the RAN elements. Various control
+applications then analyze this data to make informed decisions
 about how the RAN can best meet its data delivery objectives.
 
 The example Control Apps (xApps) in :numref:`Figure %s <fig-ric>`
@@ -536,7 +536,7 @@ counterpart to gNMI/gNOI.
 The Near-RT RIC uses the E2 interface to control the underlying RAN
 elements, including the CU, DUs, and RUs. You can think of it as the
 RAN counterpart to OpenFlow. A requirement of the E2 interface is that
-it be able to connect the Near-RT RIC to different types of RAN
+it should be able to connect the Near-RT RIC to different types of RAN
 elements from different vendors. This range is reflected in the API,
 which revolves around a *Service Model* abstraction. The idea is that
 each RAN element advertises a Service Model, which effectively defines

--- a/netvirt.rst
+++ b/netvirt.rst
@@ -259,7 +259,8 @@ virtual network are specified—either by a human user or by another
 piece of software such as a cloud automation platform. Typical API
 requests might say *“Create a layer 2 subnet”*, *“Attach VM A to
 subnet X”* or *“Apply firewall policy P to traffic entering VM B”*. As
-shown in :numref:`Figure %s <fig-three-planes>`, these API requests
+shown in :numref:`Figure %s <fig-three-planes>`, these 
+ts
 lead to the creation of *desired state*—the state that the network
 should be in. It is common to refer to the part of the system that
 receives API requests and stores them in a desired state database as
@@ -333,7 +334,7 @@ detects that the actual state no longer corresponds to the desired
 state. That triggers a fresh computation to determine the updates that
 need to be pushed to the data plane, such as new forwarding rules to
 the appropriate set of vSwitches, and deletion of data plane state at
-the hypervisor that no longer hosts one of the VMs.
+the hypervisor that no longer hosts one of the VMs. 
 
 With this architecture, we can implement a rich set of features for
 virtual networks. Provided the data plane has sufficient richness to
@@ -683,7 +684,7 @@ OVN. The OVN/CMS plugin is responsible for mapping abstractions that
 match those of the CMS into generic virtual network abstractions that
 can be stored in the *Northbound Database*. OVN uses an instance of
 ``ovsdb-server`` to implement this database. We can think of the plugin as the
-management plane and the Northbound DB as the desired state repository.
+management plane and the Northbound DB as the desired state repository. 
 
 The control plane of OVN demonstrates a significant novel feature
 compared to the generic architecture of :numref:`Figure %s
@@ -833,8 +834,7 @@ complexity of configuring segments was such that machines
 from many applications would likely sit on the same segment, creating
 opportunities for an attack to spread from one application to
 another. The lateral movement of attacks within datacenters has been well
-documented as a key strategy of successful cyberattacks over many
-years.
+documented as a key strategy of successful cyberattacks over many years.
 
 Consider the arrangement of VMs and the firewall in :numref:`Figure %s
 <fig-standard-firewall>`. Suppose that, without network

--- a/netvirt.rst
+++ b/netvirt.rst
@@ -259,8 +259,7 @@ virtual network are specified—either by a human user or by another
 piece of software such as a cloud automation platform. Typical API
 requests might say *“Create a layer 2 subnet”*, *“Attach VM A to
 subnet X”* or *“Apply firewall policy P to traffic entering VM B”*. As
-shown in :numref:`Figure %s <fig-three-planes>`, these 
-ts
+shown in :numref:`Figure %s <fig-three-planes>`, these requests
 lead to the creation of *desired state*—the state that the network
 should be in. It is common to refer to the part of the system that
 receives API requests and stores them in a desired state database as

--- a/trellis.rst
+++ b/trellis.rst
@@ -14,7 +14,7 @@ before getting into the details.
   SD-Fabric uses only bare-metal switches, equipped with the software
   described in the previous chapters, to build out the fabric. It can
   run on a mix of fixed-function and programmable pipelines but is
-  running in production with the former.
+  running in production with the former. 
 
 * SD-Fabric supports a wide range of L2/L3 features, all re-implemented
   as SDN control apps (with the exception of a DHCP server used to


### PR DESCRIPTION
I fixed a few typos in chapter 9.

Moreover, I saw that some typos I fixed (for chapters 7 and 8) were not merged in the latest commit by Prof. Peterson.
So, I saw that my fork was different from 'master'. It might seem that I haven't changed anything, but I double-checked the 'master' branch with my version and commented on the differences in the comments to my commits.

Thank you very much for maintaining this extraordinary book!

P.S.: Please ignore my last pull request (#39) (I closed it myself).